### PR TITLE
Entities load values from overview pages automatically

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -236,7 +236,7 @@ class Entity(object):
     _URI = None
     _PREFIX = None
 
-    def __new__(cls, lims, uri=None, id=None, _create_new=False):
+    def __new__(cls, lims, uri=None, id=None, _create_new=False, extra=None):
         if not uri:
             if id:
                 uri = lims.get_uri(cls._URI, id)
@@ -250,7 +250,7 @@ class Entity(object):
         except KeyError:
             return object.__new__(cls)
 
-    def __init__(self, lims, uri=None, id=None, _create_new=False):
+    def __init__(self, lims, uri=None, id=None, _create_new=False, extra=None):
         assert uri or id or _create_new
         if not _create_new:
             if hasattr(self, 'lims'): return
@@ -261,6 +261,7 @@ class Entity(object):
         self.lims = lims
         self._uri = uri
         self.root = None
+        self.extra = extra
 
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self.id)
@@ -896,6 +897,7 @@ class Protocol(Entity):
     _URI = 'configuration/protocols'
     _TAG = 'protocol'
 
+    name       = StringAttributeDescriptor('name')
     steps      = NestedEntityListDescriptor('step', ProtocolStep, 'steps')
     properties = NestedAttributeListDescriptor('protocol-property', 'protocol-properties')
 
@@ -915,8 +917,8 @@ class Workflow(Entity):
 
     name      = StringAttributeDescriptor("name")
     status    = StringAttributeDescriptor("status")
-    protocols = NestedEntityListDescriptor('protocol', Protocol, 'protocols')
-    stages    = NestedEntityListDescriptor('stage', Stage, 'stages')
+    protocols = NestedEntityListDescriptor('protocol', Protocol, 'protocols', extra=["name"])
+    stages    = NestedEntityListDescriptor('stage', Stage, 'stages', extra=["name"])
 
 
 class ReagentType(Entity):


### PR DESCRIPTION
This is the first iteration of a feature that will give callers access
to all data that's available in "overviews" of REST entities.

Each entity has usually both an overview REST endpoint as well as a details
endpoint. An example is the endpoint `configuration/workflows/<id>`,
which contains an overview of both protocols and stages.The behaviour
of this library was to fetch the details view to see those values,
so the following code would incur four calls to the server:

```
workflow = lims.get_workflows(name)[0]
print(workflow.stages[0].name)
print(workflow.protocols[0].name)

```

With this change, only the first two requests are executed.

This commit only solves the case for this particular use case and is a
hotfix. A commit will follow which cleans this up and provides the
feature for all use cases, along with integration tests.