### PR TITLE
Hack for resetting udf values

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -207,6 +207,15 @@ class UdfDictionary(object):
                 if elem.tag == tag:
                     self._elems.append(elem)
 
+    def _parse_numeric(self, value):
+        if value == 'None':
+            return None
+        try:
+            ret = int(value)
+        except ValueError:
+            ret = float(value)
+        return ret
+
     def _prepare_lookup(self):
         self._lookup = dict()
         for elem in self._elems:
@@ -215,10 +224,7 @@ class UdfDictionary(object):
             if not value:
                 value = None
             elif type == 'numeric':
-                try:
-                    value = int(value)
-                except ValueError:
-                    value = float(value)
+                value = self._parse_numeric(value)
             elif type == 'boolean':
                 value = value == 'true'
             elif type == 'date':

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -287,6 +287,16 @@ class Entity(object):
         if not force and self.root is not None: return
         self.root = self.lims.get(self.uri)
 
+    def put_none_adapted(self):
+        """
+        HACK: This method is only to be used if you want to delete a udf value.
+        Like put(), but replaces all 'None' occurences with empty string
+        in the string representation of xml tree
+        """
+        data = self.lims.tostring(ElementTree.ElementTree(self.root))
+        data = data.replace('>None<', '><')
+        self.lims.put(self.uri, data)
+
     def put(self):
         "Save this instance by doing PUT of its serialized XML."
         data = self.lims.tostring(ElementTree.ElementTree(self.root))


### PR DESCRIPTION
Purpose:
To be able to reset udf values.

Implementation
Note that there already is a __delete_item__ method in genologics, which remove the entry from the element tree, causing the xml row for that particular udf not to appear in the xml return statement. By trial and error, this simply doesn't work. The udf that are to be resetted has to be present in the xml response, with an empty string as value, i.e. "...><...".

Limitations:
Only works for single updates, not batch updates.
