### PR TITLE
Setting a UDF value to None should lead to it being removed

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -270,10 +270,13 @@ class UdfDictionary(object):
                 value = str(value)
             else:
                 raise NotImplemented("UDF type '%s'" % vtype)
-            if not isinstance(value, str):
-                if not self._is_string(value):
-                    value = str(value).encode('UTF-8')
-            node.text = value
+	    if value is None:
+	        node.text = ''
+	    else:
+		if not isinstance(value, str):
+		    if not self._is_string(value):
+			value = str(value).encode('UTF-8')
+		node.text = value
             break
         else:  # Create new entry; heuristics for type
             if self._is_string(value):


### PR DESCRIPTION
Up until now, setting a udf value to None made it into the string 'None'
if the UDF was numeric. That's why it worked for strings but not
numbers.