### PR TITLE
Add field instrument to Process

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -384,6 +384,16 @@ class File(Entity):
     is_published      = BooleanDescriptor('is-published')
 
 
+class Instrument(Entity):
+    "Instrument"
+    _URI = 'instruments'
+    _PREFIX = 'inst'
+    name = StringDescriptor('name')
+    type = StringDescriptor('type')
+    serial_number = StringDescriptor('serial-number')
+    archived = BooleanDescriptor('archived')
+
+
 class Project(Entity):
     "Project concerning a number of samples; associated with a researcher."
 
@@ -399,6 +409,7 @@ class Project(Entity):
     udt          = UdtDictionaryDescriptor()
     files        = EntityListDescriptor(nsmap('file:file'), File)
     externalids  = ExternalidListDescriptor()
+    instrument = EntityDescriptor('instrument', Instrument)
     # permissions XXX
 
 
@@ -532,6 +543,7 @@ class Process(Entity):
     udt               = UdtDictionaryDescriptor()
     files             = EntityListDescriptor(nsmap('file:file'), File)
     process_parameter = StringDescriptor('process-parameter')
+    intrument = StringDescriptor('instrument')
 
     # instrument XXX
     # process_parameters XXX


### PR DESCRIPTION
Add instrument to Process. This is because the different Clarity configuration in Sthlm, where instrument is not registered as udf, but as a separate field directly under Process. 