### PR TITLE
Dev 1159 transform to python3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Genologics'
-copyright = u'2013, Per Kraulis, Johannes Alneberg'
+project = 'Genologics'
+copyright = '2013, Per Kraulis, Johannes Alneberg'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -188,8 +188,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Genologics.tex', u'Genologics Documentation',
-   u'Per Kraulis, Johannes Alneberg', 'manual'),
+  ('index', 'Genologics.tex', 'Genologics Documentation',
+   'Per Kraulis, Johannes Alneberg', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -218,8 +218,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'genologics', u'Genologics Documentation',
-     [u'Per Kraulis, Johannes Alneberg'], 1)
+    ('index', 'genologics', 'Genologics Documentation',
+     ['Per Kraulis, Johannes Alneberg'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -232,8 +232,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Genologics', u'Genologics Documentation',
-   u'Per Kraulis, Johannes Alneberg', 'Genologics', 'One line description of project.',
+  ('index', 'Genologics', 'Genologics Documentation',
+   'Per Kraulis, Johannes Alneberg', 'Genologics', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/examples/attach_delivery_report.py
+++ b/examples/attach_delivery_report.py
@@ -20,12 +20,12 @@ lims.check_version()
 
 project = Project(lims, id="P193")
 
-print 'UDFs:'
-pprint(project.udf.items())
+print('UDFs:')
+pprint(list(project.udf.items()))
 
-print 'files:'
+print('files:')
 for file in project.files:
-    print file.content_location
+    print(file.content_location)
 
 project.udf['Delivery Report'] = "http://example.com/delivery_note.pdf"
 project.put()

--- a/examples/epp_script.py
+++ b/examples/epp_script.py
@@ -32,7 +32,7 @@ def main(lims,pid,file):
     io = p.input_output_maps
 
     # Filter them so that only PerInput output artifacts remains
-    io_filtered = filter(lambda (x,y): y['output-generation-type']=='PerInput',io)
+    io_filtered = [x_y for x_y in io if x_y[1]['output-generation-type']=='PerInput']
 
     # Fetch the first input-output artifact pair
     (input,output) = io_filtered[0]

--- a/examples/get_application.py
+++ b/examples/get_application.py
@@ -20,7 +20,7 @@ lims.check_version()
 
 project = Project(lims, id="P193")
 
-print 'UDFs:'
-pprint(project.udf.items())
+print('UDFs:')
+pprint(list(project.udf.items()))
 
-print project.udf['Application']
+print(project.udf['Application'])

--- a/examples/get_artifacts.py
+++ b/examples/get_artifacts.py
@@ -35,15 +35,15 @@ lims.check_version()
 
 name = 'jgr33'
 artifacts = lims.get_artifacts(sample_name=name)
-print len(artifacts), 'artifacts for sample name', name
+print(len(artifacts), 'artifacts for sample name', name)
 
 artifacts = lims.get_batch(artifacts)
 for artifact in artifacts:
-    print artifact, artifact.name, artifact.state
+    print(artifact, artifact.name, artifact.state)
 
-print
+print()
 artifacts = lims.get_artifacts(qc_flag='PASSED')
-print len(artifacts), 'QC PASSED artifacts'
+print(len(artifacts), 'QC PASSED artifacts')
 artifacts = lims.get_batch(artifacts)
 for artifact in artifacts:
-    print artifact, artifact.name, artifact.state
+    print(artifact, artifact.name, artifact.state)

--- a/examples/get_containers.py
+++ b/examples/get_containers.py
@@ -27,28 +27,28 @@ lims.check_version()
 ##     print len(containers), state, 'containers'
 
 containers = lims.get_containers(type='96 well plate')
-print len(containers)
+print(len(containers))
 
 container = containers[2]
-print container, container.occupied_wells
+print(container, container.occupied_wells)
 
 placements = container.get_placements()
-for location, artifact in sorted(placements.iteritems()):
-    print location, artifact.name, id(artifact), repr(artifact), artifact.root
+for location, artifact in sorted(placements.items()):
+    print(location, artifact.name, id(artifact), repr(artifact), artifact.root)
 
 containertype = container.type
-print containertype, containertype.name, containertype.x_dimension, containertype.y_dimension
+print(containertype, containertype.name, containertype.x_dimension, containertype.y_dimension)
 
 
 
 containers = lims.get_containers(type='Illumina Flow Cell',state='Populated')
 for container in containers:
-	print container.name
-	print container.id
-	print container.placements.keys()
+	print(container.name)
+	print(container.id)
+	print(list(container.placements.keys()))
 	arts=lims.get_artifacts(containername=container.name)
 	for art in arts:
-		print art.name
-		print art.type
-		print art.udf.items()
-		print art.parent_process.type.name
+		print(art.name)
+		print(art.type)
+		print(list(art.udf.items()))
+		print(art.parent_process.type.name)

--- a/examples/get_labs.py
+++ b/examples/get_labs.py
@@ -19,21 +19,21 @@ lims.check_version()
 
 # Get the list of all projects.
 labs = lims.get_labs(name='SciLifeLab')
-print len(labs), 'labs in total'
+print(len(labs), 'labs in total')
 for lab in labs:
-    print lab, id(lab), lab.name, lab.uri, lab.id
-    print lab.shipping_address.items()
-    for key, value in lab.udf.items():
-        if isinstance(value, unicode):
+    print(lab, id(lab), lab.name, lab.uri, lab.id)
+    print(list(lab.shipping_address.items()))
+    for key, value in list(lab.udf.items()):
+        if isinstance(value, str):
             value = codecs.encode(value, 'UTF-8')
-        print ' ', key, '=', value
+        print(' ', key, '=', value)
     udt = lab.udt
     if udt:
-        print 'UDT:', udt.udt
-        for key, value in udt.items():
-            if isinstance(value, unicode):
+        print('UDT:', udt.udt)
+        for key, value in list(udt.items()):
+            if isinstance(value, str):
                 value = codecs.encode(value, 'UTF-8')
-            print ' ', key, '=', value
+            print(' ', key, '=', value)
 
 lab = Lab(lims, id='2')
-print lab, id(lab), lab.name, lab.uri, lab.id
+print(lab, id(lab), lab.name, lab.uri, lab.id)

--- a/examples/get_processes.py
+++ b/examples/get_processes.py
@@ -18,12 +18,12 @@ lims.check_version()
 
 # Get the list of all processes.
 processes = lims.get_processes()
-print len(processes), 'processes in total'
+print(len(processes), 'processes in total')
 
 process = Process(lims, id='QCF-PJK-120703-24-1140')
-print process, process.id, process.type, process.type.name
+print(process, process.id, process.type, process.type.name)
 for input, output in process.input_output_maps:
     if input:
-        print 'input:', input.items()
+        print('input:', list(input.items()))
     if output:
-        print 'output:', output.items()
+        print('output:', list(output.items()))

--- a/examples/get_projects.py
+++ b/examples/get_projects.py
@@ -20,32 +20,32 @@ lims.check_version()
 
 # Get the list of all projects.
 projects = lims.get_projects()
-print len(projects), 'projects in total'
+print(len(projects), 'projects in total')
 
 # Get the list of all projects opened since May 30th 2012.
 day = '2012-05-30'
 projects = lims.get_projects(open_date=day)
-print len(projects), 'projects opened since', day
+print(len(projects), 'projects opened since', day)
 
 # Get the project with the specified LIMS id, and print some info.
 project = Project(lims, id='P193')
-print project, project.name, project.open_date, project.close_date
+print(project, project.name, project.open_date, project.close_date)
 
-print '    UDFs:'
-for key, value in project.udf.items():
-    if isinstance(value, unicode):
+print('    UDFs:')
+for key, value in list(project.udf.items()):
+    if isinstance(value, str):
         value = codecs.encode(value, 'UTF-8')
-    print ' ', key, '=', value
+    print(' ', key, '=', value)
 
 udt = project.udt
-print '    UDT:', udt.udt
-for key, value in udt.items():
-    if isinstance(value, unicode):
+print('    UDT:', udt.udt)
+for key, value in list(udt.items()):
+    if isinstance(value, str):
         value = codecs.encode(value, 'UTF-8')
-    print ' ', key, '=', value
+    print(' ', key, '=', value)
 
-print '    files:'
+print('    files:')
 for file in project.files:
-    print file.id
-    print file.content_location
-    print file.original_location
+    print(file.id)
+    print(file.content_location)
+    print(file.original_location)

--- a/examples/get_samples.py
+++ b/examples/get_samples.py
@@ -19,44 +19,44 @@ lims.check_version()
 
 # Get the list of all samples.
 samples = lims.get_samples()
-print len(samples), 'samples in total'
+print(len(samples), 'samples in total')
 
 # Get the list of samples in the project with the LIMS id KLL60.
 project = Project(lims, id='KRA61')
 samples = lims.get_samples(projectlimsid=project.id)
-print len(samples), 'samples in', project
+print(len(samples), 'samples in', project)
 
-print
+print()
 # Get the sample with the LIMS id KRA61A1
 sample = Sample(lims, id='KRA61A1')
-print sample.id, sample.name, sample.date_received, sample.uri,
-for key, value in sample.udf.items():
-    print ' ', key, '=', value
+print(sample.id, sample.name, sample.date_received, sample.uri, end=' ')
+for key, value in list(sample.udf.items()):
+    print(' ', key, '=', value)
 for note in sample.notes:
-    print 'Note', note.uri, note.content
+    print('Note', note.uri, note.content)
 for file in sample.files:
-    print 'File', file.content_location
+    print('File', file.content_location)
 
 # Get the sample with the name 'spruce_a'.
 # Check that it is the sample as the previously obtained sample;
 # not just equal, but exactly the same instance, courtesy of the Lims cache.
 samples = lims.get_samples(name='spruce_a')
-print samples[0].name, samples[0] is sample
+print(samples[0].name, samples[0] is sample)
 
 ## # Get the samples having a UDF Color with values Blue or Orange.
 samples = lims.get_samples(udf={'Color': ['Blue', 'Orange']})
-print len(samples)
+print(len(samples))
 for sample in samples:
-    print sample, sample.name, sample.udf['Color']
+    print(sample, sample.name, sample.udf['Color'])
 
 sample = samples[0]
 
-print
+print()
 # Print the submitter (researcher) for the sample.
 submitter = sample.submitter
-print submitter, submitter.email, submitter.initials, submitter.lab
+print(submitter, submitter.email, submitter.initials, submitter.lab)
 
-print
+print()
 # Print the artifact of the sample.
 artifact = sample.artifact
-print artifact, artifact.state, artifact.type, artifact.qc_flag
+print(artifact, artifact.state, artifact.type, artifact.qc_flag)

--- a/examples/get_samples2.py
+++ b/examples/get_samples2.py
@@ -15,13 +15,13 @@ lims.check_version()
 
 project = Project(lims, id='KRA61')
 samples = lims.get_samples(projectlimsid=project.id)
-print len(samples), 'samples in', project
+print(len(samples), 'samples in', project)
 
 for sample in samples:
-    print sample, sample.name, sample.date_received, sample.artifact
+    print(sample, sample.name, sample.date_received, sample.artifact)
 
 name = 'spruce_a'
 artifacts = lims.get_artifacts(sample_name=name)
-print len(artifacts), 'artifacts for sample', name
+print(len(artifacts), 'artifacts for sample', name)
 for artifact in artifacts:
-    print artifact, artifact.name, artifact.qc_flag
+    print(artifact, artifact.name, artifact.qc_flag)

--- a/examples/set_project_queued.py
+++ b/examples/set_project_queued.py
@@ -20,11 +20,11 @@ lims.check_version()
 
 # Get the project with the LIMS id KLL60, and print some info.
 project = Project(lims, id='KLL60')
-print project, project.name, project.open_date
-print project.udf.items()
+print(project, project.name, project.open_date)
+print(list(project.udf.items()))
 
 d = datetime.date(2012,1,2)
-print d
+print(d)
 
 project.udf['Queued'] = d
 project.put()

--- a/examples/set_sample_name.py
+++ b/examples/set_sample_name.py
@@ -18,14 +18,14 @@ lims.check_version()
 
 # Get the sample with the given LIMS identifier, and output its current name.
 sample = Sample(lims, id='JGR58A21')
-print sample, sample.name
+print(sample, sample.name)
 
 sample.name = 'Joels extra-proper sample-20'
 
 # Set the value of one of the UDFs
 sample.udf['Emmas field 2'] = 5
-for key, value in sample.udf.items():
-    print ' ', key, '=', value
+for key, value in list(sample.udf.items()):
+    print(' ', key, '=', value)
 
 sample.put()
-print 'Updated sample', sample
+print('Updated sample', sample)

--- a/genologics/config.py
+++ b/genologics/config.py
@@ -3,7 +3,7 @@ import sys
 import warnings
 
 try:
-    from ConfigParser import SafeConfigParser
+    from configparser import SafeConfigParser
 except ImportError:
     from configparser import SafeConfigParser
 

--- a/genologics/constants.py
+++ b/genologics/constants.py
@@ -41,7 +41,7 @@ _NSMAP = dict(
         wkfcnf='http://genologics.com/ri/workflowconfiguration'
 )
 
-for prefix, uri in _NSMAP.items():
+for prefix, uri in list(_NSMAP.items()):
     ElementTree._namespace_map[uri] = prefix
 
 _NSPATTERN = re.compile(r'(\{)(.+?)(\})')

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -11,7 +11,7 @@ from genologics.constants import nsmap
 try:
     from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 except ImportError:
-    from urlparse import urlsplit, urlparse, parse_qs, urlunparse
+    from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 
 from decimal import Decimal
 import datetime
@@ -157,7 +157,7 @@ class UdfDictionary(object):
 
     def _is_string(self, value):
         try:
-            return isinstance(value, basestring)
+            return isinstance(value, str)
         except:
             return isinstance(value, str)
 
@@ -331,7 +331,7 @@ class UdfDictionary(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         return self.__next__()
 
     def __next__(self):

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -7,11 +7,8 @@ Copyright (C) 2012 Per Kraulis
 """
 
 from genologics.constants import nsmap
+from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 
-try:
-    from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
-except ImportError:
-    from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 
 from decimal import Decimal
 import datetime

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -238,8 +238,10 @@ class UdfDictionary(object):
 
     def __setitem__(self, key, value):
         self._lookup[key] = value
+        key_found_in_xml = False
         for node in self._elems:
             if node.attrib['name'] != key: continue
+            key_found_in_xml = True
             vtype = node.attrib['type'].lower()
 
             if value is None:
@@ -278,7 +280,8 @@ class UdfDictionary(object):
                 value = str(value).encode('UTF-8')
             node.text = value
             break
-        else:  # Create new entry; heuristics for type
+
+        if not key_found_in_xml: # Create new entry; heuristics for type
             if self._is_string(value):
                 vtype = '\n' in value and 'Text' or 'String'
             elif isinstance(value, bool):

--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -272,13 +272,11 @@ class UdfDictionary(object):
                 value = str(value)
             else:
                 raise NotImplemented("UDF type '%s'" % vtype)
-	    if value is None:
-	        node.text = ''
-	    else:
-		if not isinstance(value, str):
-		    if not self._is_string(value):
-			value = str(value).encode('UTF-8')
-		node.text = value
+            if value is None:
+                value = ''
+            elif not isinstance(value, str):
+                value = str(value).encode('UTF-8')
+            node.text = value
             break
         else:  # Create new entry; heuristics for type
             if self._is_string(value):

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -61,7 +61,7 @@ class SampleHistory:
         #    logger.info(value[1]+"->"+value[0].id+"->"+key)
         logger.info("\nHistory :\n\n")
         logger.info("Input\tProcess\tProcess info")
-        for key, dict in list(self.history.items()):
+        for key, dict in self.history.items():
             logger.info(key)
             for key2, dict2 in list(dict.items()):
                 logger.info("\t{}".format(key2))

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -510,7 +510,7 @@ class Sample(Entity):
         """
         Creates a request for creating a single sample object
         """
-        udfs = kwargs.pop("udfs", list())
+        udfs = kwargs.pop("udfs", dict())
         if not isinstance(container, Container):
             raise TypeError('%s is not of type Container' % container)
         instance = super(Sample, cls)._create(lims, creation_tag='samplecreation', **kwargs)

--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -18,7 +18,7 @@ from genologics.descriptors import StringDescriptor, StringDictionaryDescriptor,
 try:
     from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 except ImportError:
-    from urlparse import urlsplit, urlparse, parse_qs, urlunparse
+    from urllib.parse import urlsplit, urlparse, parse_qs, urlunparse
 
 from xml.etree import ElementTree
 
@@ -61,11 +61,11 @@ class SampleHistory:
         #    logger.info(value[1]+"->"+value[0].id+"->"+key)
         logger.info("\nHistory :\n\n")
         logger.info("Input\tProcess\tProcess info")
-        for key, dict in self.history.items():
+        for key, dict in list(self.history.items()):
             logger.info(key)
-            for key2, dict2 in dict.items():
+            for key2, dict2 in list(dict.items()):
                 logger.info("\t{}".format(key2))
-                for key, value in dict2.items():
+                for key, value in list(dict2.items()):
                     logger.info("\t\t{0}->{1}".format(key, (value if value is not None else "None")))
         logger.info("\nHistory List")
         for art in self.history_list:
@@ -521,7 +521,7 @@ class Sample(Entity):
 
         # NOTE: This is a quick fix. I assume that it must be possible to initialize samples
         # with UDFs
-        for key, value in udfs.items():
+        for key, value in list(udfs.items()):
             attrib = {
                 "name": key,
                 "xmlns:udf": "http://genologics.com/ri/userdefined",

--- a/genologics/epp.py
+++ b/genologics/epp.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 """Contains useful and reusable code for EPP scripts.
 
 Classes, methods and exceptions.

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -19,8 +19,8 @@ import requests
 from sys import version_info
 
 if version_info[0] == 2:
-    from urlparse import urljoin
-    from urllib import urlencode
+    from urllib.parse import urljoin
+    from urllib.parse import urlencode
 else:
     from urllib.parse import urljoin
     from urllib.parse import urlencode
@@ -489,7 +489,7 @@ class Lims(object):
     def _get_params(self, **kwargs):
         "Convert keyword arguments to a kwargs dictionary."
         result = dict()
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             if value is None: continue
             result[key.replace('_', '-')] = value
         return result
@@ -497,11 +497,11 @@ class Lims(object):
     def _get_params_udf(self, udf=dict(), udtname=None, udt=dict()):
         "Convert UDF-ish arguments to a params dictionary."
         result = dict()
-        for key, value in udf.items():
+        for key, value in list(udf.items()):
             result["udf.%s" % key] = value
         if udtname is not None:
             result['udt.name'] = udtname
-        for key, value in udt.items():
+        for key, value in list(udt.items()):
             result["udt.%s" % key] = value
         return result
 
@@ -564,7 +564,7 @@ class Lims(object):
             for node in root.getchildren():
                 instance = instance_map[node.attrib['limsid']]
                 instance.root = node
-        return instance_map.values()
+        return list(instance_map.values())
 
     def put_batch(self, instances):
         """Update multiple instances using a single batch request."""

--- a/genologics/test_utils.py
+++ b/genologics/test_utils.py
@@ -26,7 +26,7 @@ def patched_get(*args, **kwargs):
         uri=kwargs['uri']
     else:
         for arg in args:
-            if isinstance(arg, str) or isinstance(arg, unicode):
+            if isinstance(arg, str) or isinstance(arg, str):
                 uri = arg
     if 'params' in kwargs:
         params=kwargs['params']
@@ -48,7 +48,7 @@ def dump_source_xml(lims):
     to be used with patched_get"""
     final_string = []
     final_string.append('{')
-    for k, v in lims.cache.iteritems():
+    for k, v in lims.cache.items():
         final_string.append("'{0}':".format(k))
         v.get()
         final_string.append('"""{0}""",'.format(v.xml().replace('\n', "\n")))

--- a/genologics/test_utils.py
+++ b/genologics/test_utils.py
@@ -26,7 +26,7 @@ def patched_get(*args, **kwargs):
         uri=kwargs['uri']
     else:
         for arg in args:
-            if isinstance(arg, str) or isinstance(arg, str):
+            if isinstance(arg, str):
                 uri = arg
     if 'params' in kwargs:
         params=kwargs['params']

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -257,10 +257,10 @@ class TestUdfDictionary(TestCase):
 
     def test___setitem__unicode(self):
         assert self._get_udf_value(self.dict1, 'test') == 'stuff'
-        self.dict1.__setitem__('test', u'unicode')
+        self.dict1.__setitem__('test', 'unicode')
         assert self._get_udf_value(self.dict1, 'test') == 'unicode'
 
-        self.dict1.__setitem__(u'test', 'unicode2')
+        self.dict1.__setitem__('test', 'unicode2')
         assert self._get_udf_value(self.dict1, 'test') == 'unicode2'
 
     def test___delitem__(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -169,19 +169,19 @@ class TestEntities(TestCase):
 
 def elements_equal(e1, e2):
     if e1.tag != e2.tag:
-        print('Tag: %s != %s' % (e1.tag, e2.tag))
+        print(('Tag: %s != %s' % (e1.tag, e2.tag)))
         return False
     if e1.text and e2.text and e1.text.strip() != e2.text.strip():
-        print('Text: %s != %s' % (e1.text.strip(), e2.text.strip()))
+        print(('Text: %s != %s' % (e1.text.strip(), e2.text.strip())))
         return False
     if e1.tail and e2.tail and e1.tail.strip() != e2.tail.strip():
-        print('Tail: %s != %s' % (e1.tail.strip(), e2.tail.strip()))
+        print(('Tail: %s != %s' % (e1.tail.strip(), e2.tail.strip())))
         return False
     if e1.attrib != e2.attrib:
-        print('Attrib: %s != %s' % (e1.attrib, e2.attrib))
+        print(('Attrib: %s != %s' % (e1.attrib, e2.attrib)))
         return False
     if len(e1) != len(e2):
-        print('length %s (%s) != length (%s) ' % (e1.tag, len(e1), e2.tag, len(e2)))
+        print(('length %s (%s) != length (%s) ' % (e1.tag, len(e1), e2.tag, len(e2))))
         return False
     return all(
         elements_equal(c1, c2) for c1, c2 in zip(sorted(e1, key=lambda x: x.tag), sorted(e2, key=lambda x: x.tag)))

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -31,7 +31,7 @@ class TestExample(TestCase):
     def test_project_example(self):
         with patch("genologics.lims.Lims.get", side_effect=test_utils.patched_get):
             pj = Project(self.lims, id='BLA1')
-            self.assertEquals(pj.name, 'Test')
+            self.assertEqual(pj.name, 'Test')
 
 
 if __name__ == '__main__':

--- a/tests/test_lims.py
+++ b/tests/test_lims.py
@@ -14,7 +14,7 @@ except NameError: # callable() doesn't exist in Python 3.0 and 3.1
 from sys import version_info
 if version_info[0] == 2:
     from mock import patch, Mock
-    import __builtin__ as builtins
+    import builtins as builtins
 else:
     from unittest.mock import patch, Mock
     import builtins

--- a/tests/to_rewrite_test_logging.py
+++ b/tests/to_rewrite_test_logging.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
 
 from os.path import isdir
 import os


### PR DESCRIPTION
Purpose:
Transform to python 3

Because "genologics" is the name of the package as well as the first module, it caused problems in python 2 that are now solved in python3. As a consequence, transforming to python3 makes the automated tests working once again. (and all tests pass)

Details:
We had a chat about the hard-to-penetrate code in descriptors.setitem the other day. Now, I have clarified that code somewhat, and also made it pass all automated tests. However, the code in setitem, as I believe, cannot perform the task it claims to do, namely to set udfs that were not included in the original fetch. As I recall, we discovered that at the beginning of our work in clarity-ext, and started to use .force() instead.