### PR TITLE
Support batch fetching the same artifact in differnt state 

### DIFF
--- a/genologics/entities.py
+++ b/genologics/entities.py
@@ -758,9 +758,6 @@ class Artifact(Entity):
     # artifact_flags XXX
     # artifact_groups XXX
 
-    def __deepcopy__(self, memodict={}):
-        return self
-
     def input_artifact_list(self):
         """Returns the input artifact ids of the parrent process."""
         input_artifact_list = []
@@ -788,14 +785,6 @@ class Artifact(Entity):
             return self.location[0]
         except:
             return None
-
-    def get_stateless_clone(self):
-        # Called before get() makes possible to use batch get
-        parsed = urlparse(self.uri)
-        import copy
-        artifact_copy = copy.deepcopy(self)
-        artifact_copy._uri = "{}://{}{}".format(parsed.scheme, parsed.netloc, parsed.path)
-        return artifact_copy
 
     def stateless(self):
         "returns the artefact independently of it's state"


### PR DESCRIPTION
Context: Artifacts can be fetched in a particular state by specifying
the `state` query parameter. Specifying no `state` parameter when
fetching artifacts will fetch it in the latest state, but Clarity
generally (I don't know of any exceptions) refers to Artifacts in a
particular state, e.g. in the input/output map for a process as well as
in the response when batch fetching Artifacts.

Patch:

The batch function was keeping a dict of all fetched entities by lims ID
rather than URI. This meant that it wasn't possible to query for the
same artifact in a different state. This patch fixes that by saving the
entries by URI instead of the ID.

Furthermore, if a user batch fetches the entries without a state
query parameter we will get entries *with* the state parameter. We have
to make sure that we map it to the correct requested Artifact in this case.