### PR TITLE
Fix warnings when running pytest

### DIFF
--- a/genologics/config.py
+++ b/genologics/config.py
@@ -1,11 +1,7 @@
 import os
 import sys
 import warnings
-
-try:
-    from configparser import SafeConfigParser
-except ImportError:
-    from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 
 
@@ -13,39 +9,39 @@ except ImportError:
 Usage:
 from genologics.config import BASEURI, USERNAME, PASSWORD
 
-Alternate Usage: 
+Alternate Usage:
 from genologics import config
-BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG = config.load_config(specified_config = <path to config file>) 
+BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG = config.load_config(specified_config = <path to config file>)
 '''
 
 spec_config = None
 
 def get_config_info(config_file):
-    config = SafeConfigParser()
-    config.readfp(open(config_file))
-    
-    
+    config = ConfigParser()
+    config.read_file(open(config_file))
+
+
     BASEURI = config.get('genologics', 'BASEURI').rstrip()
     USERNAME = config.get('genologics', 'USERNAME').rstrip()
     PASSWORD = config.get('genologics', 'PASSWORD').rstrip()
-    
+
     if config.has_section('genologics') and config.has_option('genologics','VERSION'):
         VERSION = config.get('genologics', 'VERSION').rstrip()
     else:
         VERSION = 'v2'
-        
+
     if config.has_section('logging') and config.has_option('logging','MAIN_LOG'):
         MAIN_LOG = config.get('logging', 'MAIN_LOG').rstrip()
     else:
         MAIN_LOG = None
     return BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG
-        
+
 
 def load_config(specified_config = None):
     if specified_config != None:
         config_file = specified_config
     else:
-        config = SafeConfigParser()
+        config = ConfigParser()
         try:
             conf_file = config.read([os.path.expanduser('~/.genologicsrc'), '.genologicsrc',
                         'genologics.conf', 'genologics.cfg', '/etc/genologics.conf'])
@@ -58,7 +54,7 @@ def load_config(specified_config = None):
 
     BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG = get_config_info(config_file)
 
-    return BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG   
-    
+    return BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG
+
 
 BASEURI, USERNAME, PASSWORD, VERSION, MAIN_LOG = load_config(specified_config = spec_config)


### PR DESCRIPTION
Minor fixes - warnings from pytest.

Note that it's correct to use `ConfigParser` instead of `SafeConfigParser`. This is because `SafeConfigParser` was renamed to `ConfigParser`. https://docs.python.org/3/whatsnew/3.2.html#configparser