### PR TITLE
Change deprecated syntax

### DIFF
--- a/genologics/descriptors.py
+++ b/genologics/descriptors.py
@@ -201,7 +201,7 @@ class UdfDictionary(object):
                 self._elems = elem.findall(nsmap('udf:field'))
         else:
             tag = nsmap('udf:field')
-            for elem in self.rootnode.getchildren():
+            for elem in list(self.rootnode):
                 if elem.tag == tag:
                     self._elems.append(elem)
 

--- a/genologics/lims.py
+++ b/genologics/lims.py
@@ -563,7 +563,7 @@ class Lims(object):
             uri = self.get_uri(instance.__class__._URI, 'batch/retrieve')
             data = self.tostring(ElementTree.ElementTree(root))
             root = self.post(uri, data)
-            for node in root.getchildren():
+            for node in list(root):
                 uri = node.attrib['uri']
                 if uri in instance_map:
                     instance = instance_map[uri]


### PR DESCRIPTION
Purpose:

Change deprecated syntax "getchildren" in the lxm library. Note that this is deprecated in python 3.9, but not python 3.8, which is our current running version of python. But I thought that it's just better to get rid of it.